### PR TITLE
Optional stageing of analysis input

### DIFF
--- a/src/backend/kantele/settings.py
+++ b/src/backend/kantele/settings.py
@@ -133,7 +133,7 @@ INSTRUMENT_QC_RUNNAME = os.environ.get('INSTRUMENT_QC_RUNNAME')
 # nextflow
 NXF_COMMAND = os.environ.get('NXF_COMMAND', 'nextflow')
 LIBRARY_FILE_PATH = 'databases'
-ANALYSIS_STAGESHARE = os.environ.get('STAGESHARE')
+ANALYSIS_STAGESHARE = os.environ.get('STAGESHARE', False)
 SMALL_NFRUNDIR = os.environ.get('NEXTFLOW_RUNDIR')
 LARGER_NFRUNDIR = os.environ.get('LARGER_NFRUNDIR')
 NF_RUNDIRS = {'small': SMALL_NFRUNDIR,


### PR DESCRIPTION
This will make stageing files optional, since we are migrating to a different storage architecture, which is faster than our dedicated raw data server.

Therefore we do not need to stage input files. To solve this, an analysis' `infiles` will be read from their storage location. Where as parameter passed `stagefiles` will be mounted to the analysis `rundir`. This is done so we can still do e.g. `--tdb /path/to/dbs/*` to include multiple files.

 An env var is used to toggle this behaviour, simply deploy without the `STAGESHARE` env variable if you run without a stage disk.