### PR TITLE
Make possible to use workflows with non-mzml files (e.g. pgt)

### DIFF
--- a/src/backend/analysis/admin.py
+++ b/src/backend/analysis/admin.py
@@ -2,8 +2,7 @@ from django.contrib import admin
 
 from analysis.models import (NextflowWfVersionParamset, NextflowWorkflowRepo, UserWorkflow, ParameterSet,
                              Param, FileParam, PsetParam, PsetFileParam, PsetMultiFileParam,
-                             ParamOption, PsetPredefFileParam, Proteowizard,
-                             PsetComponent)
+                             ParamOption, Proteowizard, PsetComponent)
 
 
 admin.site.register(NextflowWfVersionParamset)
@@ -14,7 +13,6 @@ admin.site.register(ParameterSet)
 admin.site.register(PsetParam)
 admin.site.register(PsetFileParam)
 admin.site.register(PsetMultiFileParam)
-admin.site.register(PsetPredefFileParam)
 admin.site.register(Param)
 admin.site.register(ParamOption)
 admin.site.register(FileParam)

--- a/src/backend/analysis/models.py
+++ b/src/backend/analysis/models.py
@@ -68,9 +68,8 @@ class NextflowWfVersionParamset(models.Model):
     nfworkflow = models.ForeignKey(NextflowWorkflowRepo, on_delete=models.CASCADE)
     paramset = models.ForeignKey(ParameterSet, on_delete=models.CASCADE)
     date = models.DateTimeField(auto_now=True)
-    kanteleanalysis_version = models.IntegerField() # TODO remove this when noone uses v1 anymore
     nfversion = models.TextField()
-    #active = models.BooleanField(default=True)
+    active = models.BooleanField(default=False)
     
     def __str__(self):
         return '{} - {}'.format(self.nfworkflow.description, self.update)
@@ -140,15 +139,6 @@ class PsetMultiFileParam(models.Model):
 
     def __str__(self):
         return '{} -- {}'.format(self.pset.name, self.param.name)
-
-# TODO get rid of predefined files, put them in some workflow config file instead
-class PsetPredefFileParam(models.Model):
-    param = models.ForeignKey(FileParam, on_delete=models.CASCADE)
-    libfile = models.ForeignKey(LibraryFile, on_delete=models.CASCADE)
-    pset = models.ForeignKey(ParameterSet, on_delete=models.CASCADE)
-
-    def __str__(self):
-        return '{} -- {} -- {}'.format(self.pset.name, self.param.name, self.libfile.description)
 
 
 class PsetParam(models.Model):

--- a/src/backend/analysis/tests.py
+++ b/src/backend/analysis/tests.py
@@ -138,7 +138,6 @@ class LoadBaseAnaTestIso(AnalysisIsobaric):
         self.assertEqual(resp.status_code, 200)
         rj = resp.json()
         checkjson = {'base_analysis': {'analysis_id': self.ana.pk, 'dsets_identical': False,
-                #'mzmldef': self.mzmldef.mzmldef,
                 'flags': [self.param1.pk],
                 'multicheck': [f'{self.param2.pk}___{self.anamcparam.value[0]}'],
                 'inputparams': {f'{self.param3.pk}': self.ananormparam.value},
@@ -168,7 +167,6 @@ class LoadBaseAnaTestIso(AnalysisIsobaric):
         self.assertEqual(resp.status_code, 200)
         rj = resp.json()
         checkjson = {'base_analysis': {'analysis_id': self.ana.pk, 'dsets_identical': True,
-                #'mzmldef': self.mzmldef.mzmldef,
                 'flags': [self.param1.pk],
                 'multicheck': [f'{self.param2.pk}___{self.anamcparam.value[0]}'],
                 'inputparams': {f'{self.param3.pk}': self.ananormparam.value},
@@ -208,7 +206,6 @@ class LoadBaseAnaTestLF(AnalysisLabelfreeSamples):
         self.assertEqual(resp.status_code, 200)
         rj = resp.json()
         checkjson = {'base_analysis': {'analysis_id': self.analf.pk, 'dsets_identical': False,
-                #'mzmldef': self.mzmldeflf.mzmldef,
                 'flags': [self.param1.pk],
                 'multicheck': [f'{self.param2.pk}___{self.anamcparamlf.value[0]}'],
                 'inputparams': {f'{self.param3.pk}': self.ananormparam.value},
@@ -592,7 +589,6 @@ class TestStoreAnalysis(AnalysisTest):
         timestamp = datetime.strftime(datetime.now(), '%Y%m%d_')
         self.assertEqual(resp.status_code, 200)
         ana = am.Analysis.objects.last()
-        #self.assertEqual(ana.analysismzmldef.mzmldef, postdata['components']['mzmldef'])
         self.assertEqual(ana.analysissampletable.samples, {'hello': 'yes'})
         for adsif in ana.analysisdsinputfile_set.all():
             self.assertEqual(adsif.analysisdset.dataset_id, self.ds.pk)

--- a/src/backend/analysis/tests.py
+++ b/src/backend/analysis/tests.py
@@ -1,12 +1,15 @@
 from datetime import datetime, timedelta
+import json
 
 from django.utils import timezone
 from django.db.models import Max
+from django.contrib.auth.models import User
 
 from kantele.tests import BaseTest
 from analysis import models as am
 from rawstatus import models as rm
 from jobs import models as jm
+from jobs import jobs as jj
 from datasets import models as dm
 
 
@@ -18,7 +21,7 @@ class AnalysisTest(BaseTest):
         self.param2, _ = am.Param.objects.get_or_create(name='a chbox', nfparam='--multi', ptype='multi', help='help')
         self.param3, _ = am.Param.objects.get_or_create(name='a num', nfparam='--num', ptype='number', help='help')
         self.popt1, _ = am.ParamOption.objects.get_or_create(param=self.param2, name='opt 1', value='nr1')
-        popt2, _ = am.ParamOption.objects.get_or_create(param=self.param2, name='opt 2', value='nr2')
+        self.popt2, _ = am.ParamOption.objects.get_or_create(param=self.param2, name='opt 2', value='nr2')
         self.pfn1, _ = am.FileParam.objects.get_or_create(name='fp1', nfparam='--fp1', filetype=self.ft, help='help')
 
         self.ft2, _ = rm.StoredFileType.objects.get_or_create(name='result ft', filetype='txt')
@@ -49,13 +52,13 @@ class AnalysisTest(BaseTest):
         # Create analysis for isoquant:
         self.ana, _ = am.Analysis.objects.get_or_create(user=self.user, name='testana_iso', storage_dir='testdir_iso')
         am.DatasetAnalysis.objects.get_or_create(analysis=self.ana, dataset=self.ds)
-        anajob, _ = jm.Job.objects.get_or_create(funcname='testjob', kwargs={}, state='done',
+        self.anajob = jm.Job.objects.create(funcname='testjob', kwargs={}, state=jj.Jobstates.WAITING,
                 timestamp=timezone.now())
         self.nfs, _ = am.NextflowSearch.objects.get_or_create(analysis=self.ana, nfwfversionparamset=self.nfwf,
-                workflow=self.wf, token='tok123', job=anajob)
+                workflow=self.wf, token='tok123', job=self.anajob)
         am.AnalysisParam.objects.get_or_create(analysis=self.ana, param=self.param1, value=True)
         self.anamcparam, _ = am.AnalysisParam.objects.get_or_create(analysis=self.ana, param=self.param2,
-                value=[self.popt1.value])
+                value=[self.popt1.pk])
         self.ananormparam, _ = am.AnalysisParam.objects.get_or_create(analysis=self.ana,
                 param=self.param3, value=3)
         self.anamfparam, _ = am.AnalysisFileParam.objects.get_or_create(analysis=self.ana,
@@ -68,10 +71,10 @@ class AnalysisTest(BaseTest):
         # Create analysis for LF
         self.analf, _ = am.Analysis.objects.get_or_create(user=self.user, name='testana_lf', storage_dir='testdirlf')
         am.DatasetAnalysis.objects.get_or_create(analysis=self.analf, dataset=self.oldds)
-        anajoblf, _ = jm.Job.objects.get_or_create(funcname='testjob', kwargs={}, state='done',
+        self.anajoblf = jm.Job.objects.create(funcname='testjob', kwargs={}, state=jj.Jobstates.WAITING,
                 timestamp=timezone.now())
         self.nfslf, _ = am.NextflowSearch.objects.get_or_create(analysis=self.analf, nfwfversionparamset=self.nfwf,
-                workflow=self.wf, token='tok12344', job=anajoblf)
+                workflow=self.wf, token='tok12344', job=self.anajoblf)
 
         am.AnalysisParam.objects.get_or_create(analysis=self.analf, param=self.param1, value=True)
         self.anamcparamlf, _ = am.AnalysisParam.objects.get_or_create(analysis=self.analf, param=self.param2,
@@ -85,21 +88,22 @@ class AnalysisTest(BaseTest):
         self.resultfnlf, _ = am.AnalysisResultFile.objects.get_or_create(analysis=self.analf,
                 sfile=self.anasfile2)
 
+        self.anaset = am.AnalysisSetname.objects.create(analysis=self.ana, setname='set1')
+        self.ads1 = am.AnalysisDatasetSetname.objects.create(analysis=self.ana,
+                dataset=self.ds, setname=self.anaset, regex='hej')
+        self.adsif = am.AnalysisDSInputFile.objects.create(analysis=self.ana, sfile=self.f3sfmz, analysisdset=self.ads1)
+        self.isoqvals = {'denoms': {self.qch.pk: True}, 'sweep': False, 'report_intensity': False}
+        am.AnalysisIsoquant.objects.create(analysis=self.ana, setname=self.anaset,
+                value=self.isoqvals)
+        self.samples = am.AnalysisSampletable.objects.create(analysis=self.ana,
+                samples=[[self.qch.name, self.anaset.setname, self.projsam1.sample, 'thegroup']])
+
 
 class AnalysisIsobaric(AnalysisTest):
     '''For preloaded isobaric analysis (base or new) we load setnames and isoquant'''
 
     def setUp(self):
         super().setUp()
-        self.anaset, _ = am.AnalysisSetname.objects.get_or_create(analysis=self.ana, setname='set1')
-        self.ads1, _ = am.AnalysisDatasetSetname.objects.get_or_create(analysis=self.ana,
-                dataset=self.ds, setname=self.anaset, regex='hej')
-        self.adsif = am.AnalysisDSInputFile.objects.create(analysis=self.ana, sfile=self.f3sfmz, analysisdset=self.ads1)
-        self.isoqvals = {'denoms': [self.qch.pk], 'sweep': False, 'report_intensity': False}
-        am.AnalysisIsoquant.objects.get_or_create(analysis=self.ana, setname=self.anaset,
-                value=self.isoqvals)
-        self.samples, _ = am.AnalysisSampletable.objects.get_or_create(analysis=self.ana,
-                samples=[[self.qch.name, self.anaset.setname, self.projsam1.sample, 'thegroup']])
 
 
 class AnalysisLabelfreeSamples(AnalysisTest):
@@ -152,7 +156,7 @@ class LoadBaseAnaTestIso(AnalysisIsobaric):
                     'setname': f'{self.ads1.setname.setname}', 'filesaresets': False,
                     'files': {}, 'picked_ftype': f'mzML (pwiz {self.f3sfmz.mzmlfile.pwiz.version_description})'}},
                 }
-        self.assertJSONEqual(resp.content.decode('utf-8'), checkjson)
+        self.assertJSONEqual(resp.content.decode('utf-8'), json.dumps(checkjson))
 
     def test_same_dsets(self):
         '''Base analysis requested has a single dset connected, this analysis too, so we need
@@ -182,7 +186,7 @@ class LoadBaseAnaTestIso(AnalysisIsobaric):
                     'filesaresets': False, 'files': {}},
                     }
                 }
-        self.assertJSONEqual(resp.content.decode('utf-8'), checkjson)
+        self.assertJSONEqual(resp.content.decode('utf-8'), json.dumps(checkjson))
 
     def test_no_params_or_post(self):
         url = f'{self.url}1/1/'
@@ -206,7 +210,7 @@ class LoadBaseAnaTestLF(AnalysisLabelfreeSamples):
         checkjson = {'base_analysis': {'analysis_id': self.analf.pk, 'dsets_identical': False,
                 #'mzmldef': self.mzmldeflf.mzmldef,
                 'flags': [self.param1.pk],
-                'multicheck': [f'{self.param2.pk}___{self.anamcparam.value[0]}'],
+                'multicheck': [f'{self.param2.pk}___{self.anamcparamlf.value[0]}'],
                 'inputparams': {f'{self.param3.pk}': self.ananormparam.value},
                 'multifileparams': {f'{self.pfn1.pk}': {'0': self.tmpsf.pk}},
                 'fileparams': {f'{self.pfn2.pk}': self.txtsf.pk},
@@ -221,7 +225,7 @@ class LoadBaseAnaTestLF(AnalysisLabelfreeSamples):
                         'setname': self.afs2.sample}}},
                     },
                 }
-        self.assertJSONEqual(resp.content.decode('utf-8'), checkjson)
+        self.assertJSONEqual(resp.content.decode('utf-8'), json.dumps(checkjson))
 
 
 class TestGetAnalysis(AnalysisIsobaric):
@@ -267,7 +271,7 @@ class TestGetAnalysis(AnalysisIsobaric):
         self.assertInHTML(html_dsids, resphtml)
         self.isoqvals = {'denoms': [self.qch.pk], 'sweep': False, 'report_intensity': False}
         html_ana = f'''<script id="analysis_data" type="application/json">
-        {{"analysis_id": {self.ana.pk}, "editable": false, "wfversion_id": {self.nfwf.pk}, "wfid": {self.wf.pk}, "analysisname": "{self.ana.name}", "flags": [{self.param1.pk}], "multicheck": ["{self.param2.pk}___{self.anamcparam.value[0]}"], "inputparams": {{"{self.param3.pk}": {self.ananormparam.value}}}, "multifileparams": {{"{self.pfn1.pk}": {{"0": {self.tmpsf.pk}}}}}, "fileparams": {{"{self.pfn2.pk}": {self.txtsf.pk}}}, "isoquants": {{"{self.anaset.setname}": {{"chemistry": "{self.ds.quantdataset.quanttype.shortname}", "channels": {{"{self.qch.name}": ["{self.projsam1.sample}", {self.qch.pk}]}}, "samplegroups": {{"{self.samples.samples[0][0]}": "{self.samples.samples[0][3]}"}}, "denoms": [{self.qch.pk}], "report_intensity": false, "sweep": false}}}}, "added_results": {{}}, "base_analysis": false}}
+        {{"analysis_id": {self.ana.pk}, "editable": true, "wfversion_id": {self.nfwf.pk}, "wfid": {self.wf.pk}, "analysisname": "{self.ana.name}", "flags": [{self.param1.pk}], "multicheck": ["{self.param2.pk}___{self.anamcparam.value[0]}"], "inputparams": {{"{self.param3.pk}": {self.ananormparam.value}}}, "multifileparams": {{"{self.pfn1.pk}": {{"0": {self.tmpsf.pk}}}}}, "fileparams": {{"{self.pfn2.pk}": {self.txtsf.pk}}}, "isoquants": {{"{self.anaset.setname}": {{"chemistry": "{self.ds.quantdataset.quanttype.shortname}", "channels": {{"{self.qch.name}": ["{self.projsam1.sample}", {self.qch.pk}]}}, "samplegroups": {{"{self.samples.samples[0][0]}": "{self.samples.samples[0][3]}"}}, "denoms": {{"{self.qch.pk}": true}}, "report_intensity": false, "sweep": false}}}}, "added_results": {{}}, "base_analysis": false}}
         </script>
         '''
         self.assertInHTML(html_ana, resphtml)
@@ -356,6 +360,7 @@ class TestGetDatasetsIso(AnalysisIsobaric):
                     'ft_files': {mztype: [{'ft_name': mztype, 'id': self.f3sfmz.pk, 'name': self.f3sfmz.filename, 'fr': '', 'setname': '', 'sample': ''}],
                         self.ft.name: [{'ft_name': self.ft.name, 'id': self.f3sf.pk, 'name': self.f3sf.filename, 'fr': '', 'setname': '', 'sample': ''}],
                         },
+                    'incomplete_files': [],
                     'picked_ftype': mztype,
                     'filesaresets': False,
                     }},
@@ -389,6 +394,7 @@ class TestGetDatasetsIso(AnalysisIsobaric):
                     'ft_files': {mztype: [{'ft_name': mztype, 'id': self.f3sfmz.pk, 'name': self.f3sfmz.filename, 'fr': '', 'setname': '', 'sample': ''}],
                         self.ft.name: [{'ft_name': self.ft.name, 'id': self.f3sf.pk, 'name': self.f3sf.filename, 'fr': '', 'setname': '', 'sample': ''}],
                         },
+                    'incomplete_files': [],
                     'picked_ftype': mztype,
                     'filesaresets': False,
                     }},
@@ -426,6 +432,7 @@ class TestGetDatasetsLF(AnalysisLabelfreeSamples):
                     'channels': False,
                     'ft_files': {self.ft.name: [{'ft_name': self.ft.name, 'id': self.oldsf.pk, 'name': self.oldsf.filename, 'fr': '', 'setname': self.oldqsf.projsample.sample, 'sample': self.oldqsf.projsample.sample}],
                         },
+                    'incomplete_files': [],
                     'picked_ftype': self.ft.name,
                     'filesaresets': False,
                     }},
@@ -460,6 +467,7 @@ class TestGetDatasetsLF(AnalysisLabelfreeSamples):
                     'channels': False,
                     'ft_files': {self.ft.name: [{'ft_name': self.ft.name, 'id': self.oldsf.pk, 'name': self.oldsf.filename, 'fr': '', 'setname': self.afs2.sample, 'sample': self.oldqsf.projsample.sample}],
                         },
+                    'incomplete_files': [],
                     'picked_ftype': self.ft.name,
                     'filesaresets': True,
                     }},
@@ -601,6 +609,248 @@ class TestStoreAnalysis(AnalysisTest):
         checkjson = {'error': False, 'analysis_id': ana.pk}
         self.assertJSONEqual(resp.content.decode('utf-8'), checkjson)
 
-    # FIXME existing ana
 
-    # FIXME fail tests
+class TestStoreExistingIsoAnalysis(AnalysisIsobaric):
+    url = '/analysis/store/'
+
+    def test_existing_analysis(self):
+        quant = self.ds.quantdataset.quanttype
+        params = {'flags': {self.param1.pk: True}, 'inputparams': {self.param3.pk: 42}, 
+                'multicheck': {self.param2.pk: [self.popt1.pk]}}
+        postdata = {'dsids': [f'{self.ds.pk}'],
+            'analysis_id': self.ana.pk,
+            'infiles': {self.f3sfmz.pk: 1},
+            'picked_ftypes': {self.ds.pk: f'mzML (pwiz {self.f3sfmz.mzmlfile.pwiz.version_description})'},
+            'nfwfvid': self.nfwf.pk,
+            'dssetnames': {self.ds.pk: 'setA'},
+            'components': {'ISOQUANT_SAMPLETABLE': {'hello': 'yes'},
+                'INPUTDEF': 'a',
+                'ISOQUANT': {'setA': {'chemistry': quant.shortname,
+                    'denoms': {x.channel.name: [f'{x}_sample', x.channel.id] for x in quant.quanttypechannel_set.all()},
+                    'report_intensity': False,
+                    'sweep': False,
+                    }},
+                },
+            'analysisname': 'Test existing analysis',
+            'frregex': {f'{self.ds.pk}': 'fr_find'},
+            'fnsetnames': {},
+            'params': params,
+            'singlefiles': {self.pfn2.pk: self.sflib.pk},
+            'multifiles': {self.pfn1.pk: [self.sfusr.pk]},
+            'base_analysis': {'isComplement': False,
+                'dsets_identical': False,
+                'selected': False,
+                'typedname': '',
+                'fetched': {},
+                'resultfiles': [],
+                },
+            'wfid': self.wf.pk,
+            }
+        resp = self.cl.post(self.url, content_type='application/json', data=postdata)
+        timestamp = datetime.strftime(datetime.now(), '%Y%m%d_')
+        self.assertEqual(resp.status_code, 200)
+        self.ana.refresh_from_db()
+        self.assertEqual(self.ana.analysissampletable.samples, {'hello': 'yes'})
+        for adsif in self.ana.analysisdsinputfile_set.all():
+            self.assertEqual(adsif.analysisdset.dataset_id, self.ds.pk)
+            self.assertEqual(adsif.analysisdset.setname.setname, postdata['dssetnames'][self.ds.pk])
+            self.assertEqual(adsif.analysisdset.regex, postdata['frregex'][f'{self.ds.pk}'])
+        for ap in self.ana.analysisparam_set.all():
+            pt = {'multi': 'multicheck', 'text': 'inputparams', 'number': 'inputparams',
+                    'flag': 'flags'}[ap.param.ptype]
+            self.assertEqual(ap.value, params[pt][ap.param_id])
+        self.assertEqual(self.ana.name, postdata['analysisname'])
+        fullname = f'{self.ana.pk}_{self.wftype.name}_{self.ana.name}_{timestamp}'
+        # This test flakes if executed right at midnight due to timestamp in assert string
+        self.assertEqual(self.ana.storage_dir[:-5], f'{self.ana.user.username}/{fullname}')
+        checkjson = {'error': False, 'analysis_id': self.ana.pk}
+        self.assertJSONEqual(resp.content.decode('utf-8'), checkjson)
+        self.assertFalse(hasattr(self.ana, 'analysisbaseanalysis'))
+
+
+class TestStoreExistingLFAnalysis(AnalysisLabelfreeSamples):
+    url = '/analysis/store/'
+
+    def test_existing_analysis(self):
+        c_ch = am.PsetComponent.ComponentChoices
+        am.PsetComponent.objects.get_or_create(pset=self.pset,
+                component=am.PsetComponent.ComponentChoices.COMPLEMENT_ANALYSIS)
+        quant = self.oldds.quantdataset.quanttype
+        params = {'flags': {}, 'inputparams': {self.param3.pk: 42}, 
+                'multicheck': {self.param2.pk: [self.popt2.pk]}}
+        postdata = {'dsids': [f'{self.oldds.pk}'],
+            'analysis_id': self.analf.pk,
+            'infiles': {self.oldsf.pk: 23},
+            'picked_ftypes': {self.oldds.pk: self.ft.name},
+            'nfwfvid': self.nfwf.pk,
+            'dssetnames': {},
+            'components': {'ISOQUANT_SAMPLETABLE': False,
+                'INPUTDEF': 'hej',
+                'ISOQUANT': {},
+                },
+            'analysisname': 'Test existing analysis LF',
+            'frregex': {f'{self.oldds.pk}': ''},
+            'fnsetnames': {self.oldsf.pk: 'testsample'},
+            'params': params,
+            'singlefiles': {self.pfn2.pk: self.sflib.pk},
+            'multifiles': {self.pfn1.pk: [self.sfusr.pk]},
+            'base_analysis': {'isComplement': True,
+                'runFromPSM': False,
+                'dsets_identical': False,
+                'selected': self.ana.pk,
+                'typedname': '',
+                'fetched': {},
+                'resultfiles': [],
+                },
+            'wfid': self.wf.pk,
+            }
+        resp = self.cl.post(self.url, content_type='application/json', data=postdata)
+        timestamp = datetime.strftime(datetime.now(), '%Y%m%d_')
+        self.assertEqual(resp.status_code, 200)
+        self.analf.refresh_from_db()
+        self.assertFalse(hasattr(self.analf, 'analysissampletable'))
+        self.assertEqual(self.analf.analysisdsinputfile_set.count(), 0)
+        for afs in self.analf.analysisfilesample_set.all():
+            self.assertEqual(postdata['fnsetnames'][afs.sfile_id], afs.sample)
+        for ap in self.analf.analysisparam_set.all():
+            pt = {'multi': 'multicheck', 'text': 'inputparams', 'number': 'inputparams',
+                    'flag': 'flags'}[ap.param.ptype]
+            self.assertEqual(ap.value, params[pt][ap.param_id])
+        self.assertEqual(self.analf.analysisparam_set.filter(param=self.param1).count(), 0)
+        self.assertEqual(self.analf.name, postdata['analysisname'])
+        self.assertEqual(self.analf.analysisfileparam_set.filter(param=self.pfn2, sfile=self.sflib).count(), 1)
+        self.assertEqual(self.analf.analysisfileparam_set.filter(param=self.pfn1, sfile=self.sfusr).count(), 1)
+        self.assertEqual(self.analf.analysisfileparam_set.count(), 2)
+        fullname = f'{self.analf.pk}_{self.wftype.name}_{self.analf.name}_{timestamp}'
+        # This test flakes if executed right at midnight due to timestamp in assert string
+        self.assertEqual(self.analf.storage_dir[:-5], f'{self.analf.user.username}/{fullname}')
+        checkjson = {'error': False, 'analysis_id': self.analf.pk}
+        self.assertJSONEqual(resp.content.decode('utf-8'), checkjson)
+        ba = am.AnalysisBaseanalysis.objects.get(analysis=self.analf)
+        self.assertEqual(ba.base_analysis_id, self.ana.pk)
+        self.assertTrue(ba.is_complement)
+        self.assertFalse(ba.rerun_from_psms)
+        self.assertJSONEqual(json.dumps(ba.shadow_isoquants), json.dumps({self.anaset.setname: {
+            **self.isoqvals,
+            'chemistry': self.ds.quantdataset.quanttype.shortname,
+            'channels': {self.qch.name: [self.projsam1.sample, self.qch.pk]},
+            'samplegroups': {self.samples.samples[0][0]: self.samples.samples[0][3]},
+            }}))
+        self.assertJSONEqual(json.dumps(ba.shadow_dssetnames), json.dumps({
+            self.ds.pk: {'setname': self.ads1.setname.setname, 'regex': self.ads1.regex}}))
+
+    def test_failing(self):
+        # no sample annotations
+        # no stored files at all
+        # raw but not sf stored
+        fn = 'noqt_fn'
+        path = 'noqt_stor'
+        raw = rm.RawFile.objects.create(name=fn, producer=self.prod,
+                source_md5='noqt_fakemd5',
+                size=100, date=timezone.now(), claimed=True)
+        newrun = dm.RunName.objects.create(experiment=self.ds.runname.experiment, name='noqt_ds')
+        newds = dm.Dataset.objects.create(runname=newrun, datatype=self.ds.datatype, 
+                storage_loc=path, storageshare=self.ds.storageshare, date=timezone.now())
+        dsr = dm.DatasetRawFile.objects.create(dataset=newds, rawfile=raw)
+        dm.DatasetOwner.objects.create(dataset=newds, user=self.user)
+        params = {'flags': {}, 'inputparams': {self.param3.pk: 42}, 
+                'multicheck': {self.param2.pk: [self.popt2.pk]}}
+        picked_ft = self.ft.name
+        postdata = {'dsids': [f'{newds.pk}'],
+            'analysis_id': 0,
+            'infiles': {},
+            'picked_ftypes': {newds.pk: picked_ft},
+            'nfwfvid': self.nfwf.pk,
+            'dssetnames': {},
+            'components': {'ISOQUANT_SAMPLETABLE': False,
+                'INPUTDEF': 'hej',
+                'ISOQUANT': {},
+                },
+            'analysisname': 'Test existing analysis LF',
+            'frregex': {f'{newds.pk}': ''},
+            'fnsetnames': {},
+            'params': params,
+            'singlefiles': {self.pfn2.pk: self.sflib.pk},
+            'multifiles': {self.pfn1.pk: [self.sfusr.pk]},
+            'base_analysis': {'isComplement': True,
+                'runFromPSM': False,
+                'dsets_identical': False,
+                'selected': self.ana.pk,
+                'typedname': '',
+                'fetched': {},
+                'resultfiles': [],
+                },
+            'wfid': self.wf.pk,
+            }
+        resp = self.cl.post(self.url, content_type='application/json', data=postdata)
+        self.assertEqual(resp.status_code, 400)
+        dsname = f'{self.ds.runname.experiment.project.name} / {self.ds.runname.experiment.name} / {newrun.name}'
+        err = resp.json()['error']
+        self.assertIn(f'File(s) or channels in dataset {dsname} do not have sample annotations, '
+                'please edit the dataset first', err)
+        self.assertIn(f'No stored files exist for dataset {dsname}', err)
+        self.assertIn(f'Dataset {dsname} contains registered files that dont have a storage '
+                'entry yet. Maybe the transferring hasnt been finished, or they are deleted.', err)
+
+        # picked files fewer than raw files
+        sf = rm.StoredFile.objects.create(rawfile=raw, filename=fn, md5=raw.source_md5, 
+                filetype=self.ft, servershare=self.ssnewstore, path=path, checked=True)
+        raw2 = rm.RawFile.objects.create(name=fn, producer=self.prod,
+                source_md5='fewer_fakemd5',
+                size=100, date=timezone.now(), claimed=True)
+        dsr = dm.DatasetRawFile.objects.create(dataset=newds, rawfile=raw2)
+        sf2 = rm.StoredFile.objects.create(rawfile=raw2, filename=fn, md5=raw2.source_md5, 
+                filetype=self.ft, servershare=self.ssnewstore, path=path, checked=True)
+        sfmz = rm.StoredFile.objects.create(rawfile=raw2, filename=fn, md5='raw2mzml',
+                filetype=self.ft, servershare=self.ssnewstore, path=path, checked=True)
+        mzml = am.MzmlFile.objects.create(sfile=sfmz, pwiz=self.pwiz)
+        picked_ft = f'mzML (pwiz {mzml.pwiz.version_description})'
+        postdata['picked_ftypes'] = {newds.pk: picked_ft}
+        resp = self.cl.post(self.url, content_type='application/json', data=postdata)
+        self.assertEqual(resp.status_code, 400)
+        dsname = f'{self.ds.runname.experiment.project.name} / {self.ds.runname.experiment.name} / {newrun.name}'
+        err = resp.json()['error']
+        self.assertIn(f'Files of type {picked_ft} are fewer than '
+                f'raw files, please fix - for dataset {dsname}', err)
+
+        # multi type dset
+        sf2.filetype = self.ft2
+        sf2.save()
+        sfmz.delete()
+        picked_ft = self.ft.name
+        postdata['picked_ftypes'] = {newds.pk: picked_ft}
+        resp = self.cl.post(self.url, content_type='application/json', data=postdata)
+        self.assertEqual(resp.status_code, 400)
+        dsname = f'{self.ds.runname.experiment.project.name} / {self.ds.runname.experiment.name} / {newrun.name}'
+        err = resp.json()['error']
+        self.assertIn(f'Files of multiple datatypes exist in dataset {dsname}', err)
+
+        # already running
+        postdata['analysis_id'] = self.analf.pk
+        self.anajoblf.state = jj.Jobstates.PROCESSING
+        self.anajoblf.save()
+        resp = self.cl.post(self.url, content_type='application/json', data=postdata)
+        err = resp.json()['error']
+        print(err)
+        self.assertEqual(resp.json(), {'error': 'This analysis has a running or queued job, '
+            'it cannot be edited, please stop the job first'})
+        self.assertEqual(resp.status_code, 403)
+
+        # Already done
+        self.anajoblf.state = jj.Jobstates.DONE
+        self.anajoblf.save()
+        resp = self.cl.post(self.url, content_type='application/json', data=postdata)
+        self.assertEqual(resp.status_code, 403)
+        err = resp.json()['error']
+        self.assertEqual(resp.json(), {'error': 'This analysis has already finished running, '
+            'it cannot be edited'})
+
+        # No permission
+        newuser = User.objects.create(username='noaccess', email='noemail')
+        self.ana.user=newuser
+        self.ana.save()
+        postdata['analysis_id'] = self.ana.pk
+        resp = self.cl.post(self.url, content_type='application/json', data=postdata)
+        self.assertEqual(resp.status_code, 403)
+        err = resp.json()['error']
+        self.assertEqual(resp.json(), {'error': 'You do not have permission to edit this analysis'})

--- a/src/backend/analysis/views.py
+++ b/src/backend/analysis/views.py
@@ -153,19 +153,18 @@ def load_base_analysis(request, wfversion_id, baseanid):
     for dsid in dsets:
         dssfiles = rm.StoredFile.objects.filter(rawfile__datasetrawfile__dataset_id=dsid,
                 deleted=False, purged=False, checked=True)
-        print(dssfiles.count())
         dsrawfiles = dssfiles.filter(mzmlfile__isnull=True)
         dset_ftype = dsrawfiles.distinct('filetype')
         rawftype = dset_ftype.get().filetype.name
         dsf_by_type = {rawftype: dsrawfiles}
         if dsrawfiles.filter(rawfile__producer__msinstrument__isnull=False).count():
             nrrawfiles = dsrawfiles.count()
-    #        ds_msfiles, _ = get_msdataset_files_by_type(dssfiles, nrrawfiles)
-    #        dsf_by_type.update(ds_msfiles)
+            ds_msfiles, _ = get_msdataset_files_by_type(dssfiles, nrrawfiles)
+            dsf_by_type.update(ds_msfiles)
 
-    #    for ft, sf_qset in dsf_by_type.items():
-    #        if not analysis_dsfiles[dsid].difference({x.pk for x in sf_qset}):
-    #            dsets[dsid]['picked_ftype'] = ft
+        for ft, sf_qset in dsf_by_type.items():
+            if not analysis_dsfiles[dsid].difference({x.pk for x in sf_qset}):
+                dsets[dsid]['picked_ftype'] = ft
 
 
     # Isoquants, sampletables, and also shadow isoquants (isoquants from the base analysis

--- a/src/backend/datasets/views.py
+++ b/src/backend/datasets/views.py
@@ -1407,9 +1407,6 @@ def save_samples(request):
     if stype_dups:
         return JsonResponse({'error': f'Sampletypes need to be identical for identical sample IDs, check {", ".join(stype_dups)}'}, status=400)
 
-    # FIXME labelcheck single can remove the sample names from datatype so we dont have to store those?
-    # kind of nice to store but not sure yet
-
     # Check if all channels/samples have values for sampletype and species
     dset = models.Dataset.objects.select_related('runname__experiment__project').get(pk=dset_id)
     if data['multiplex']:

--- a/src/backend/datasets/views.py
+++ b/src/backend/datasets/views.py
@@ -1476,6 +1476,7 @@ def save_samples(request):
             'sample IDs', 'sample_dups': projsamples}, status=400)
 
     # All is ready for saving or updating
+    # FIXME this line can be removed, not used
     lf_qtid = models.QuantType.objects.get(name='labelfree').pk
     if is_update := models.DatasetComponentState.objects.filter(dataset=dset,
             dtcomp=models.DatasetUIComponent.SAMPLES, state=models.DCStates.OK).count():

--- a/src/backend/home/tests.py
+++ b/src/backend/home/tests.py
@@ -17,7 +17,7 @@ class MzmlTests(BaseTest):
         ps, _ = am.ParameterSet.objects.get_or_create(name='')
         nfw, _ = am.NextflowWorkflowRepo.objects.get_or_create(description='', repo='')
         self.nfwv, _ = am.NextflowWfVersionParamset.objects.get_or_create(update='', commit='', filename='',
-                nfworkflow=nfw, paramset=ps, kanteleanalysis_version=1, nfversion='')
+                nfworkflow=nfw, paramset=ps, nfversion='', active=True)
         self.pw, _ = am.Proteowizard.objects.get_or_create(version_description='',
                 container_version='', nf_version=self.nfwv, is_docker=True)
 

--- a/src/backend/kantele/tests.py
+++ b/src/backend/kantele/tests.py
@@ -75,7 +75,7 @@ class BaseTest(TestCase):
         msit, _ = rm.MSInstrumentType.objects.get_or_create(name='test')
         rm.MSInstrument.objects.get_or_create(producer=self.prod, instrumenttype=msit,
                 filetype=self.ft)
-        self.qt, _ = dm.QuantType.objects.get_or_create(name='testqt', shortname='tqt')
+        self.qt, _ = dm.QuantType.objects.get_or_create(name='testqt', shortname='testqtplex')
         self.qch, _ = dm.QuantChannel.objects.get_or_create(name='thech')
         self.qtch, _ = dm.QuantTypeChannel.objects.get_or_create(quanttype=self.qt, channel=self.qch) 
         self.lfqt, _ = dm.QuantType.objects.get_or_create(name='labelfree', shortname='lf')
@@ -120,7 +120,7 @@ class BaseTest(TestCase):
         wfv, _ = am.NextflowWfVersionParamset.objects.get_or_create(update='pwiz wfv base',
                 commit='pwiz ci base', filename='pwiz.nf', nfworkflow=nfw,
                 paramset=pset, nfversion='', active=True)
-        self.pwiz = am.Proteowizard.objects.create(version_description='',
+        self.pwiz = am.Proteowizard.objects.create(version_description='pwversion desc1',
                 container_version='', nf_version=wfv)
         self.f3sfmz, _ = rm.StoredFile.objects.update_or_create(rawfile=self.f3raw,
                 filename=f'{fn3}.mzML', md5='md5_for_f3sf_mzml', filetype=self.ft,
@@ -140,7 +140,7 @@ class BaseTest(TestCase):
         self.oldds, _ = dm.Dataset.objects.update_or_create(date=self.oldp.registered,
                 runname=self.oldrun, datatype=self.dtype, defaults={
                     'storageshare': self.ssoldstorage, 'storage_loc': self.oldstorloc})
-        dm.QuantDataset.objects.get_or_create(dataset=self.oldds, quanttype=self.qt)
+        dm.QuantDataset.objects.get_or_create(dataset=self.oldds, quanttype=self.lfqt)
         dm.DatasetComponentState.objects.create(dataset=self.oldds, dtcomp=self.dtcompfiles, state=dm.DCStates.OK)
         dm.DatasetComponentState.objects.create(dataset=self.oldds, dtcomp=self.dtcompsamples, state=dm.DCStates.OK)
         self.contact, _ = dm.ExternalDatasetContact.objects.get_or_create(dataset=self.oldds,
@@ -156,7 +156,7 @@ class BaseTest(TestCase):
                     md5=self.oldraw.source_md5, filetype=self.ft,
                     defaults={'servershare': self.ssoldstorage, 'path': self.oldstorloc, 
                         'checked': True})
-        dm.QuantSampleFile.objects.get_or_create(rawfile=self.olddsr, projsample=self.projsam2)
+        self.oldqsf = dm.QuantSampleFile.objects.create(rawfile=self.olddsr, projsample=self.projsam2)
 
         # Tmp rawfile
         tmpfn = 'raw2'

--- a/src/backend/kantele/tests.py
+++ b/src/backend/kantele/tests.py
@@ -119,7 +119,7 @@ class BaseTest(TestCase):
                 description='pwiz_repo_base desc', repo='pwiz_repo_base')
         wfv, _ = am.NextflowWfVersionParamset.objects.get_or_create(update='pwiz wfv base',
                 commit='pwiz ci base', filename='pwiz.nf', nfworkflow=nfw,
-                paramset=pset, kanteleanalysis_version=1, nfversion='')
+                paramset=pset, nfversion='', active=True)
         self.pwiz = am.Proteowizard.objects.create(version_description='',
                 container_version='', nf_version=wfv)
         self.f3sfmz, _ = rm.StoredFile.objects.update_or_create(rawfile=self.f3raw,

--- a/src/frontend/analysis/src/App.svelte
+++ b/src/frontend/analysis/src/App.svelte
@@ -32,14 +32,12 @@ let base_analysis = {
   dsets_identical: false,
   selected: false,
   typedname: '',
-  fetched: {},
   resultfiles: [],
 }
 
 let adding_analysis = {
   selected: false,
   typedname: '',
-  fetched: {},
 }
 
 let added_analyses_order = [];
@@ -294,9 +292,6 @@ async function fetchDatasetDetails(fetchdsids) {
       dsets[x].changed = false;
     })
     Object.entries(dsets).filter(x=>x[1].prefrac).forEach(x=>matchFractions(dsets[x[0]]));
-// grouped_files treat here
-// f-end easiest is to keep ftype_name in key, pass that to api
-// api parses out key used from dsinputfiles, and parses in files from key on save
   }
 }
 
@@ -371,7 +366,6 @@ async function loadBaseAnalysis() {
         dsets[dsid].frregex = resds.frregex;
         dsets[dsid].filesaresets = resds.filesaresets;
         dsets[dsid].picked_ftype = resds.picked_ftype;
-        // FIXME address w resds.picked or ds.picked ?
         dsets[dsid].ft_files[resds.picked_ftype]
           .filter(x => x.id in resds.files)
           .forEach(x => {
@@ -625,7 +619,7 @@ onMount(async() => {
       {/if}
     </div>
     {/if}
-    <DynamicSelect bind:intext={base_analysis.typedname} bind:selectval={base_analysis.selected} on:selectedvalue={e => loadBaseAnalysis()} niceName={x => x.name} fetchUrl="/analysis/baseanalysis/show/" bind:fetchedData={base_analysis.fetched} />
+    <DynamicSelect bind:intext={base_analysis.typedname} bind:selectval={base_analysis.selected} on:selectedvalue={e => loadBaseAnalysis()} niceName={x => x.name} fetchUrl="/analysis/baseanalysis/show/" />
 	</div>
   {/if}
 
@@ -852,7 +846,7 @@ onMount(async() => {
   <div class="box">
     <div class="title is-5">Input files</div>
     Pick previous analyses to use results as input if needed:
-    <DynamicSelect bind:intext={adding_analysis.typedname} bind:selectval={adding_analysis.selected} on:selectedvalue={e => loadAnalysisResults()} niceName={x => x.name} fetchUrl="/analysis/baseanalysis/show/" bind:fetchedData={adding_analysis.fetched} />
+    <DynamicSelect bind:intext={adding_analysis.typedname} bind:selectval={adding_analysis.selected} on:selectedvalue={e => loadAnalysisResults()} niceName={x => x.name} fetchUrl="/analysis/baseanalysis/show/" />
 
     <div class="tags">
     {#each added_analyses_order as anaid}

--- a/src/frontend/analysis/src/App.svelte
+++ b/src/frontend/analysis/src/App.svelte
@@ -271,6 +271,9 @@ async function fetchDatasetDetails(fetchdsids) {
       dsets[x].changed = false;
     })
     Object.entries(dsets).filter(x=>x[1].prefrac).forEach(x=>matchFractions(dsets[x[0]]));
+// grouped_files treat here
+// f-end easiest is to keep ftype_name in key, pass that to api
+// api parses out key used from dsinputfiles, and parses in files from key on save
   }
 }
 

--- a/src/frontend/analysis/src/App.svelte
+++ b/src/frontend/analysis/src/App.svelte
@@ -246,6 +246,7 @@ async function fetchWorkflow() {
   to get input files that are results of any previous workflow that has
   the same datasets as input
   */
+  notif = {errors: {}, messages: {}, links: {}};
   let url = new URL('/analysis/workflow', document.location)
   const params = {dsids: dsids.join(','), wfvid: config.wfversion.id};
   url.search = new URLSearchParams(params).toString();

--- a/src/frontend/analysis/src/App.svelte
+++ b/src/frontend/analysis/src/App.svelte
@@ -626,6 +626,16 @@ onMount(async() => {
     {#if ds.dtype.toLowerCase() === 'labelcheck'}
     <span class="has-text-primary">{ds.proj} // Labelcheck // {ds.run} // {ds.qtype.name} // {ds.instruments.join(',')}</span>
     {:else}
+        <div class="subtitle is-6 has-text-primary">
+          <span>{ds.proj} // {ds.exp} // {ds.run} //</span>
+          {#if !ds.prefrac}
+          <span>{ds.dtype}</span>
+          {:else if ds.hr}
+          <span>{ds.hr}</span>
+          {:else}
+          <span>{ds.prefrac}</span>
+          {/if}
+			  </div>
 		<div class="columns">
 		  <div class="column">
         {#if !ds.prefrac && !ds.qtype.is_isobaric}
@@ -637,21 +647,36 @@ onMount(async() => {
           <input type="text" class="input" placeholder="Name of set" bind:value={ds.setname} on:change={e => updateIsoquant(ds.id)}>
 			  </div>
         {/if}
-        <div class="subtitle is-6 has-text-primary">
-          <span>{ds.proj} // {ds.exp} // {ds.run} //</span>
-          {#if !ds.prefrac}
-          <span>{ds.dtype}</span>
-          {:else if ds.hr}
-          <span>{ds.hr}</span>
-          {:else}
-          <span>{ds.prefrac}</span>
-          {/if}
-			  </div>
         {#if ds.changed}
         <div class="has-text-danger">
           <span>This dataset has changed files while editing  <button on:click={e => fetchDatasetDetails([ds.id])} class="button is-small">Reload dataset</button></span>
         </div>
         {/if}
+        <!-- FIXME -->
+        {#if ds.nrstoredfiles.refined_mzML}
+			  <div class="subtitle is-6"><strong>Enforcing use of refined mzML(s)</strong></div>
+        {/if}
+
+        {#if wf && ds.prefrac && 'PREFRAC' in wf.components}
+        <div class="field">
+					<label class="label">Regex for fraction detection</label>
+          <input type="text" class="input" on:change={e => matchFractions(ds)} bind:value={ds.frregex}>
+				</div>
+				<span>{matchedFr[ds.id]} fractions matched</span>
+        {/if}
+			</div>
+
+			<div class="column">
+        <div class="field">
+					<label class="label">File type to use</label>
+          <div class="select">
+            <select bind:value={ds.picked_ftype}>
+              {#each Object.keys(ds.ft_files) as ft}
+              <option value={ft}>{ft}</option>
+              {/each}
+            </select>
+          </div>
+        </div>
 			  <div class="subtitle is-6">
 				  <span>{ds.qtype.name}</span>
           {#each Object.entries(ds.nrstoredfiles) as sf}
@@ -659,21 +684,7 @@ onMount(async() => {
           {/each}
 				  <span>// {ds.instruments.join(', ')} </span>
 			  </div>
-        {#if ds.nrstoredfiles.refined_mzML}
-			  <div class="subtitle is-6"><strong>Enforcing use of refined mzML(s)</strong></div>
-        {/if}
-			</div>
-			<div class="column">
-      {#if wf}
-      
-      {#if ds.prefrac && 'PREFRAC' in wf.components}
-        <div class="field">
-					<label class="label">Regex for fraction detection</label>
-          <input type="text" class="input" on:change={e => matchFractions(ds)} bind:value={ds.frregex}>
-				</div>
-				<span>{matchedFr[ds.id]} fractions matched</span>
-        {/if}
-      {/if}
+
 			</div>
 		</div>
     {#if ds.filesaresets}

--- a/src/frontend/analysis/src/App.svelte
+++ b/src/frontend/analysis/src/App.svelte
@@ -269,6 +269,7 @@ async function fetchDatasetDetails(fetchdsids) {
   // as in other places here! Instead, {errmsg: [err1, err2, ..]}
   if (result.error) {
     result.errmsg.forEach(msg => {
+      notif.errors['Errors found in datasets, please fix and refresh this page'] = 1;
       notif.errors[msg] = 1;
       setTimeout(function(msg) { notif.errors[msg] = 0 } , flashtime, msg);
     });

--- a/src/frontend/analysis/src/App.svelte
+++ b/src/frontend/analysis/src/App.svelte
@@ -648,10 +648,6 @@ onMount(async() => {
           <span>This dataset has changed files while editing  <button on:click={e => fetchDatasetDetails([ds.id])} class="button is-small">Reload dataset</button></span>
         </div>
         {/if}
-        <!-- FIXME -->
-        {#if ds.nrstoredfiles.refined_mzML}
-			  <div class="subtitle is-6"><strong>Enforcing use of refined mzML(s)</strong></div>
-        {/if}
 
         {#if wf && ds.prefrac && 'PREFRAC' in wf.components}
         <div class="field">
@@ -675,9 +671,7 @@ onMount(async() => {
         </div>
 			  <div class="subtitle is-6">
 				  <span>{ds.qtype.name}</span>
-          {#each Object.entries(ds.nrstoredfiles) as sf}
-		      <span> // {sf[1]} {sf[0]} files </span>
-          {/each}
+		      <span> // {ds.nrstoredfiles[0]} {ds.nrstoredfiles[1]} files </span>
 				  <span>// {ds.instruments.join(', ')} </span>
 			  </div>
 


### PR DESCRIPTION
This PR will fix:

- [x] run workflows with other input than mzML
- [x] selectable input in case there is mzML
- [X] no more predefined files, let nextflow config do the lifting
- [x] stop analysis on errors at loading datasets

Addresses points mentioned in #47
Fixes #80 

Create new PR for:
- move refining to analysis, needs its own DB (mouse) 