### PR TITLE
Refine with choosable db

### DIFF
--- a/src/backend/analysis/jobs.py
+++ b/src/backend/analysis/jobs.py
@@ -43,7 +43,7 @@ class RefineMzmls(DatasetJob):
     def process(self, **kwargs):
         """Return all a dset mzMLs but not those that have a refined mzML associated, to not do extra work."""
         analysis = models.Analysis.objects.get(pk=kwargs['analysis_id'])
-        analysis.nextflowsearch.token = 'nf-{}'.format(uuid4())
+        analysis.nextflowsearch.token = f'nf-{uuid4()}'
         analysis.nextflowsearch.save()
         nfwf = models.NextflowWfVersionParamset.objects.get(pk=kwargs['wfv_id'])
         dbfn = rm.StoredFile.objects.get(pk=kwargs['dbfn_id'])
@@ -106,7 +106,7 @@ class RunLongitudinalQCWorkflow(SingleFileJob):
                       '--db': [(dbfn.servershare.name, dbfn.path, dbfn.filename)]}
         timestamp = datetime.strftime(analysis.date, '%Y%m%d_%H.%M')
         models.NextflowSearch.objects.update_or_create(defaults={'nfwfversionparamset_id': nfwf.id, 
-            'job_id': self.job_id, 'workflow_id': wf.id, 'token': 'nf-{}'.format(uuid4)},
+            'job_id': self.job_id, 'workflow_id': wf.id, 'token': f'nf-{uuid4()}'},
             analysis=analysis)
         run = {'timestamp': timestamp,
                'analysis_id': analysis.id,
@@ -255,7 +255,7 @@ class RunNextflowWorkflow(MultiFileJob):
             job = job.save()
 
         # token is unique per job run:
-        analysis.nextflowsearch.token = 'nf-{}'.format(uuid4())
+        analysis.nextflowsearch.token = f'nf-{uuid4()}'
         analysis.nextflowsearch.save()
         timestamp = datetime.strftime(analysis.date, '%Y%m%d_%H.%M')
         run = {'analysis_id': analysis.id,

--- a/src/backend/analysis/jobs.py
+++ b/src/backend/analysis/jobs.py
@@ -43,6 +43,8 @@ class RefineMzmls(DatasetJob):
     def process(self, **kwargs):
         """Return all a dset mzMLs but not those that have a refined mzML associated, to not do extra work."""
         analysis = models.Analysis.objects.get(pk=kwargs['analysis_id'])
+        analysis.nextflowsearch.token = 'nf-{}'.format(uuid4())
+        analysis.nextflowsearch.save()
         nfwf = models.NextflowWfVersionParamset.objects.get(pk=kwargs['wfv_id'])
         dbfn = rm.StoredFile.objects.get(pk=kwargs['dbfn_id'])
         stagefiles = {'--tdb': [(dbfn.servershare.name, dbfn.path, dbfn.filename)]}
@@ -70,6 +72,7 @@ class RefineMzmls(DatasetJob):
             params.extend(['--isobaric', kwargs['qtype']])
         run = {'timestamp': timestamp,
                'analysis_id': analysis.id,
+               'token': analysis.nextflowsearch.token,
                'wf_commit': nfwf.commit,
                'nxf_wf_fn': nfwf.filename,
                'repo': nfwf.nfworkflow.repo,
@@ -102,8 +105,12 @@ class RunLongitudinalQCWorkflow(SingleFileJob):
         stagefiles = {'--raw': [(mzml.servershare.name, mzml.path, mzml.filename)],
                       '--db': [(dbfn.servershare.name, dbfn.path, dbfn.filename)]}
         timestamp = datetime.strftime(analysis.date, '%Y%m%d_%H.%M')
+        models.NextflowSearch.objects.update_or_create(defaults={'nfwfversionparamset_id': nfwf.id, 
+            'job_id': self.job_id, 'workflow_id': wf.id, 'token': 'nf-{}'.format(uuid4)},
+            analysis=analysis)
         run = {'timestamp': timestamp,
                'analysis_id': analysis.id,
+               'token': analysis.nextflowsearch.token,
                'rf_id': mzml.rawfile_id,
                'wf_commit': nfwf.commit,
                'nxf_wf_fn': nfwf.filename,
@@ -112,9 +119,6 @@ class RunLongitudinalQCWorkflow(SingleFileJob):
                'filename': mzml.filename,
                'instrument': mzml.rawfile.producer.name,
                }
-        models.NextflowSearch.objects.update_or_create(defaults={'nfwfversionparamset_id': nfwf.id, 
-            'job_id': self.job_id, 'workflow_id': wf.id, 'token': 'nf-{}'.format(uuid4)},
-            analysis=analysis)
         self.run_tasks.append(((run, params, stagefiles, ','.join(nfwf.profiles), nfwf.nfversion), {}))
         analysis.log.append('[{}] Job queued'.format(datetime.strftime(timezone.now(), '%Y-%m-%d %H:%M:%S')))
         analysis.save()

--- a/src/backend/analysis/jobs.py
+++ b/src/backend/analysis/jobs.py
@@ -44,7 +44,7 @@ class RefineMzmls(DatasetJob):
         """Return all a dset mzMLs but not those that have a refined mzML associated, to not do extra work."""
         analysis = models.Analysis.objects.get(pk=kwargs['analysis_id'])
         nfwf = models.NextflowWfVersionParamset.objects.get(pk=kwargs['wfv_id'])
-        dbfn = models.LibraryFile.objects.get(pk=kwargs['dbfn_id']).sfile
+        dbfn = rm.StoredFile.objects.get(pk=kwargs['dbfn_id'])
         stagefiles = {'--tdb': [(dbfn.servershare.name, dbfn.path, dbfn.filename)]}
         mzmlfiles = self.getfiles_query(**kwargs).filter(checked=True, deleted=False, purged=False,
                 mzmlfile__isnull=False)

--- a/src/backend/analysis/tasks.py
+++ b/src/backend/analysis/tasks.py
@@ -215,7 +215,7 @@ def refine_mzmls(self, run, params, mzmls, stagefiles, profiles, nf_version):
         os.makedirs(infile_target_dir, exist_ok=True)
     with open(os.path.join(rundir, 'mzmldef.txt'), 'w') as fp:
         for fn in mzmls:
-            fntarget = os.path.join(infile_target_dir, f'{fn["sfid"]}___{fn["fn"]}')
+            fntarget = os.path.join(infile_target_dir, f'{fn["sfid"]}___{fn["fn"]}\n')
             fp.write(fntarget)
             # Create link or staged mzML:
             if infiledir_or_nostage:

--- a/src/backend/analysis/tasks.py
+++ b/src/backend/analysis/tasks.py
@@ -205,24 +205,42 @@ def refine_mzmls(self, run, params, mzmls, stagefiles, profiles, nf_version):
     params, gitwfdir, infiledir_or_nostage = prepare_nextflow_run(run, self.request.id, rundir, stagefiles, mzmls, params)
     if infiledir_or_nostage:
         stagedir_to_rm = os.path.split(infiledir_or_nostage)[0]
+        infile_target_dir = infiledir_or_nostage
     else:
         stagedir_to_rm = False
-    # FIXME Should we use components here? -- internal pipe so maybe not?
+        # No stageing on system -> we need to copy mzml to rundir, symlinks made below
+        # will not be accessible to container. We could also change the names
+        # of the actual mzML files temporarily in a pre-refine-job
+        infile_target_dir = os.path.join(rundir, 'infile_links')
+        os.makedirs(infile_target_dir, exist_ok=True)
     with open(os.path.join(rundir, 'mzmldef.txt'), 'w') as fp:
         for fn in mzmls:
+            fntarget = os.path.join(infile_target_dir, f'{fn["sfid"]}___{fn["fn"]}')
+            fp.write(fntarget)
+            # Create link or staged mzML:
             if infiledir_or_nostage:
                 fnpath = os.path.join(infiledir_or_nostage, fn['fn'])
+                if not os.path.exists(fntarget):
+                    os.symlink(fnpath, fntarget)
             else:
+                # if not stageing but direct pulling from server, files will not
+                # be accessible to container if we make links to the rundir, so we 
+                # will copy them here, "stage them anyway"
                 fnpath = os.path.join(settings.SHAREMAP[fn['servershare']], fn['path'], fn['fn'])
-            # FIXME not have set, etc, pass rawfnid here!
-            mzstr = f'{fnpath}\t{fn["sfid"]}\n'
-            fp.write(mzstr)
-    params.extend(['--mzmldef', os.path.join(rundir, 'mzmldef.txt')])
+                if os.path.exists(fntarget) and os.path.getsize(fntarget) != os.path.getsize(fnpath):
+                    # file exists but is not correct, delete first
+                    os.remove(fntarget)
+                if not os.path.exists(fntarget):
+                    try:
+                        shutil.copy(fnpath, fntarget)
+                    except FileNotFoundError:
+                        taskfail_update_db(taskid, f'Could not stage mzML files for refine, '
+                                'file {fn["fn"]} does not exist with path {fnpath}')
+                    except Exception:
+                        taskfail_update_db(taskid, f'Unknown error, could not stage mzML files '
+                                'for refine')
+    params.extend(['--input', os.path.join(rundir, 'mzmldef.txt')])
     outfiles = execute_normal_nf(run, params, rundir, gitwfdir, self.request.id, nf_version, profiles)
-    # TODO ideally do this:
-    # ln -s stage mzML with {dbid}___{filename}.mzML
-    # This keeps dbid / ___ split out of the NF workflow 
-    # We dont necessarily need outfiles, we can read from infiles
     outfiles_db = {}
     fileurl = urljoin(settings.KANTELEHOST, reverse('jobs:mzmlfiledone'))
     outpath = os.path.join(run['outdir'], os.path.split(rundir)[-1])

--- a/src/backend/analysis/tasks.py
+++ b/src/backend/analysis/tasks.py
@@ -215,8 +215,8 @@ def refine_mzmls(self, run, params, mzmls, stagefiles, profiles, nf_version):
         os.makedirs(infile_target_dir, exist_ok=True)
     with open(os.path.join(rundir, 'mzmldef.txt'), 'w') as fp:
         for fn in mzmls:
-            fntarget = os.path.join(infile_target_dir, f'{fn["sfid"]}___{fn["fn"]}\n')
-            fp.write(fntarget)
+            fntarget = os.path.join(infile_target_dir, f'{fn["sfid"]}___{fn["fn"]}')
+            fp.write(f'{fntarget}\n')
             # Create link or staged mzML:
             if infiledir_or_nostage:
                 fnpath = os.path.join(infiledir_or_nostage, fn['fn'])

--- a/src/backend/analysis/tasks.py
+++ b/src/backend/analysis/tasks.py
@@ -234,10 +234,10 @@ def refine_mzmls(self, run, params, mzmls, stagefiles, profiles, nf_version):
                     try:
                         shutil.copy(fnpath, fntarget)
                     except FileNotFoundError:
-                        taskfail_update_db(taskid, f'Could not stage mzML files for refine, '
+                        taskfail_update_db(self.request.id, f'Could not stage mzML files for refine, '
                                 'file {fn["fn"]} does not exist with path {fnpath}')
                     except Exception:
-                        taskfail_update_db(taskid, f'Unknown error, could not stage mzML files '
+                        taskfail_update_db(self.request.id, f'Unknown error, could not stage mzML files '
                                 'for refine')
     params.extend(['--input', os.path.join(rundir, 'mzmldef.txt')])
     outfiles = execute_normal_nf(run, params, rundir, gitwfdir, self.request.id, nf_version, profiles)

--- a/src/backend/home/views.py
+++ b/src/backend/home/views.py
@@ -783,9 +783,8 @@ def fetch_dset_details(dset):
     if dset.datatype_id not in nonms_dtypes:
         nrstoredfiles = {'raw': rawfiles.count()}
         info.update({'refine_mzmls': [], 'convert_dataset_mzml': [], 'refine_dbs': []})
-        # FIXME hardcoded refine version, wtf
         info['refine_versions'] = [{'id': x.pk, 'name': x.update} for x in
-                anmodels.NextflowWfVersionParamset.objects.filter(
+                anmodels.NextflowWfVersionParamset.objects.filter(active=True,
                 userworkflow__name__icontains='refine',
                 userworkflow__wftype=anmodels.UserWorkflow.WFTypeChoices.SPEC)]
         # go through all filejobs that are not done to find current jobs and get pwiz id

--- a/src/backend/home/views.py
+++ b/src/backend/home/views.py
@@ -948,7 +948,7 @@ def refine_mzmls(request):
     analysis = anmodels.Analysis.objects.create(user=request.user, name=f'refine_dataset_{dset.pk}')
     job = jj.create_job('refine_mzmls', dset_id=dset.pk, analysis_id=analysis.id, wfv_id=data['wfid'],
             dstshare_id=res_share.pk, dbfn_id=data['dbid'], qtype=dset.quantdataset.quanttype.shortname)
-    uwf = anmodels.UserWorkflow.objects.get(nfwfversionparamset_id=data['wfid'],
+    uwf = anmodels.UserWorkflow.objects.get(nfwfversionparamsets=data['wfid'],
             wftype=anmodels.UserWorkflow.WFTypeChoices.SPEC)
     anmodels.NextflowSearch.objects.update_or_create(analysis=analysis, defaults={
         'nfwfversionparamset_id': data['wfid'], 'job_id': job.id, 'workflow_id': uwf.pk, 'token': ''})

--- a/src/backend/home/views.py
+++ b/src/backend/home/views.py
@@ -947,8 +947,12 @@ def refine_mzmls(request):
     # Refine data
     # FIXME get analysis if it does exist, in case someone reruns?
     analysis = anmodels.Analysis.objects.create(user=request.user, name=f'refine_dataset_{dset.pk}')
-    jj.create_job('refine_mzmls', dset_id=dset.pk, analysis_id=analysis.id, wfv_id=data['wfid'],
+    job = jj.create_job('refine_mzmls', dset_id=dset.pk, analysis_id=analysis.id, wfv_id=data['wfid'],
             dstshare_id=res_share.pk, dbfn_id=data['dbid'], qtype=dset.quantdataset.quanttype.shortname)
+    uwf = anmodels.UserWorkflow.objects.get(nfwfversionparamset_id=data['wfid'],
+            wftype=anmodels.UserWorkflow.WFTypeChoices.SPEC)
+    anmodels.NextflowSearch.objects.update_or_create(analysis=analysis, defaults={
+        'nfwfversionparamset_id': data['wfid'], 'job_id': job.id, 'workflow_id': uwf.pk, 'token': ''})
     return JsonResponse({})
 
 

--- a/src/backend/jobs/management/commands/runjobs.py
+++ b/src/backend/jobs/management/commands/runjobs.py
@@ -53,8 +53,8 @@ def run_ready_jobs(job_fn_map, job_ds_map, active_jobs):
             # Register dsets FIXME
             ds_ids = jwrapper.get_dsids_jobrunner(**job.kwargs)
             job_ds_map[job.id] = set(ds_ids)
-            # New jobs can be running/error when e.g. the jobrunner is restarted:
-            if job.state in [Jobstates.PROCESSING, Jobstates.ERROR]:
+            # New jobs can be running/error/just-revoked when e.g. the jobrunner is restarted:
+            if job.state in [Jobstates.PROCESSING, Jobstates.ERROR, Jobstates.REVOKING]:
                 active_jobs.add(job.pk)
 
         # Just print info about ERROR-jobs, but also process tasks

--- a/src/backend/kantele/settings.py
+++ b/src/backend/kantele/settings.py
@@ -131,10 +131,12 @@ LARGER_NFRUNDIR = os.environ.get('LARGER_NFRUNDIR')
 NF_RUNDIRS = {'small': SMALL_NFRUNDIR,
               'larger': LARGER_NFRUNDIR,
             }
+
+# hardcoded name for fasta DBs
+DBFA_FT_NAME = 'database'
 # FIXME let QC pipe use its own DB (downloadable or in lehtio server)
 LONGQC_FADB_ID = os.environ.get('LONGQC_DBID')
 MZREFINER_NXFWFV_ID = os.environ.get('REFINE_MZML_WFVID')
-MZREFINER_FADB_ID = os.environ.get('REFINE_MZML_DBID')
 
 # django
 ALLOWED_HOSTS = os.environ.get('HOST_DOMAIN', KANTELEHOST).split(',')

--- a/src/backend/kantele/tests.py
+++ b/src/backend/kantele/tests.py
@@ -115,18 +115,18 @@ class BaseTest(TestCase):
         dm.DatasetSample.objects.create(dataset=self.ds, projsample=self.projsam1)
 
         # Pwiz/mzml
-        pset, _ = am.ParameterSet.objects.get_or_create(name='pwiz_pset_base')
-        nfw, _ = am.NextflowWorkflowRepo.objects.get_or_create(
-                description='pwiz_repo_base desc', repo='pwiz_repo_base')
-        wfv, _ = am.NextflowWfVersionParamset.objects.get_or_create(update='pwiz wfv base',
-                commit='pwiz ci base', filename='pwiz.nf', nfworkflow=nfw,
-                paramset=pset, nfversion='', active=True)
+        self.pset = am.ParameterSet.objects.create(name='pset_base')
+        self.nfw = am.NextflowWorkflowRepo.objects.create(
+                description='repo_base desc', repo='repo_base')
+        wfv = am.NextflowWfVersionParamset.objects.create(update='pwiz wfv base',
+                commit='pwiz ci base', filename='pwiz.nf', nfworkflow=self.nfw,
+                paramset=self.pset, nfversion='', active=True)
         self.pwiz = am.Proteowizard.objects.create(version_description='pwversion desc1',
                 container_version='', nf_version=wfv)
-        self.f3sfmz, _ = rm.StoredFile.objects.update_or_create(rawfile=self.f3raw,
-                filename=f'{fn3}.mzML', md5='md5_for_f3sf_mzml', filetype=self.ft,
-                defaults={'servershare': self.ssnewstore, 'path': self.storloc, 'checked': True})
-        am.MzmlFile.objects.get_or_create(sfile=self.f3sfmz, pwiz=self.pwiz)
+        self.f3sfmz = rm.StoredFile.objects.create(rawfile=self.f3raw, filename=f'{fn3}.mzML',
+                md5='md5_for_f3sf_mzml', filetype=self.ft, servershare=self.ssnewstore,
+                path=self.storloc, checked=True)
+        am.MzmlFile.objects.create(sfile=self.f3sfmz, pwiz=self.pwiz)
 
         # Project/dataset/files on old storage
         oldfn = 'raw1'

--- a/src/frontend/home/src/Table.svelte
+++ b/src/frontend/home/src/Table.svelte
@@ -74,7 +74,7 @@ function findQuery(event) {
   }
 }
 
-async function showDetails(itemId) {
+async function hoverDetails(itemId) {
   showDetailBox = itemId; 
   detailsLoaded = false;
   detailBoxContent = await getdetails(itemId);
@@ -173,7 +173,7 @@ div.spinner {
     <tr>
       <td>
         <input type="checkbox" bind:group={selected} value={row.id}>
-        <a on:click={e => clickSingleDetails(rowid)} on:mouseenter={e => showDetails(rowid)} on:mouseleave={e => showDetailBox = false}>
+        <a on:click={e => clickSingleDetails(rowid)} on:mouseenter={e => hoverDetails(rowid)} on:mouseleave={e => showDetailBox = false}>
           <span class="has-text-info icon is-small"> <i class="fa fa-eye"></i></span>
           {#if showDetailBox === rowid}
           <div class="box" >


### PR DESCRIPTION
Enable picking a database when correcting precursor errors in mzML. Previously this was a locked setting which defaulted to a human database on our system. Also the workflow now becomes choosable (which previously was also a config setting even though there's a select box for it!). This also displays the refine jobs and fixes logging of QC jobs in the analysis tab, which had errored earlier.

Fixes #62