### PR TITLE
Remove zip extension from rawfile name, not only storedfile

### DIFF
--- a/src/backend/jobs/views.py
+++ b/src/backend/jobs/views.py
@@ -236,7 +236,7 @@ def downloaded_file(request):
     if 'client_id' not in data or not taskclient_authorized(
             data['client_id'], [settings.STORAGECLIENT_APIKEY]):
         return HttpResponseForbidden()
-    sfile = StoredFile.objects.get(pk=data['sf_id'])
+    sfile = StoredFile.objects.select_related('rawfile').get(pk=data['sf_id'])
     # Delete file in tmp download area
     if data['do_md5check']:
         sfile.checked = sfile.rawfile.source_md5 == data['md5']
@@ -245,6 +245,8 @@ def downloaded_file(request):
         sfile.checked = True
     if data['unzipped']:
         sfile.filename = sfile.filename.rstrip('.zip')
+        sfile.rawfile.name = sfile.rawfile.name.rstrip('.zip')
+        sfile.rawfile.save()
     sfile.save()
     fpath = os.path.join(settings.TMP_UPLOADPATH, f'{sfile.rawfile.pk}.{sfile.filetype.filetype}')
     os.unlink(fpath)

--- a/src/backend/jobs/views.py
+++ b/src/backend/jobs/views.py
@@ -16,6 +16,7 @@ from jobs import models
 
 from rawstatus.models import (RawFile, StoredFile, ServerShare, StoredFileType,
         SwestoreBackedupFile, PDCBackedupFile, Producer, UploadToken)
+from rawstatus import jobs as rj
 from analysis import models as am
 from analysis.views import write_analysis_log
 from dashboard import views as dashviews
@@ -248,7 +249,7 @@ def downloaded_file(request):
         sfile.rawfile.name = sfile.rawfile.name.rstrip('.zip')
         sfile.rawfile.save()
     sfile.save()
-    fpath = os.path.join(settings.TMP_UPLOADPATH, f'{sfile.rawfile.pk}.{sfile.filetype.filetype}')
+    fpath = rj.create_upload_dst_web(sfile.rawfile.pk, sfile.filetype.filetype)
     os.unlink(fpath)
     if 'task' in data:
         set_task_done(data['task'])


### PR DESCRIPTION
The commit says 19, but that is wrong, in #89 we introduced a fix for #37, changing filenames when these change during uploads. What I missed was that this happens every time we upload zip files, which get reset after the unzip is ready - but ONLY on the storedfile table, not in the rawfile table. Then we cant move files to dataset etc. This should fix that problem.

found by @rui-branca